### PR TITLE
Store session information in next event intent

### DIFF
--- a/Template_Skill/src/main/java/com/neong/voice/wolfpack/CalendarConversation.java
+++ b/Template_Skill/src/main/java/com/neong/voice/wolfpack/CalendarConversation.java
@@ -217,6 +217,12 @@ public class CalendarConversation extends Conversation {
 		String eventFormat = "The next event is {summary}, on {start:date} at {start:time}.";
 		String eventSsml = CalendarHelper.formatEventSsml(eventFormat, results);
 		String repromptSsml = "Is there anything you would like to know about this event?";
+		
+		Map<String, Integer> savedEvent = CalendarHelper.extractEventIds(results, 1);
+		
+		session.setAttribute(ATTRIB_RECENTLYSAIDEVENTS, savedEvent);
+		session.setAttribute(ATTRIB_STATEID, SessionState.USER_HEARD_EVENTS);
+		session.removeAttribute(ATTRIB_SAVEDDATE);
 
 		return newAffirmativeResponse(eventSsml, repromptSsml);
 	}


### PR DESCRIPTION
This pull request would allow the handleNextEventIntent() method to store information in the session so that users can ask for things like the price or location of the event that was heard. 